### PR TITLE
Fix storage_size

### DIFF
--- a/ass_renderer/renderer.py
+++ b/ass_renderer/renderer.py
@@ -56,12 +56,8 @@ class AssRenderer:
         self._track = self._library.make_track()
         self._track.load_ass_file(ass_file, video_resolution)
 
-        self._renderer.storage_size = (
-            self._track.play_res_x,
-            self._track.play_res_y,
-        )
+        self._renderer.storage_size = video_resolution
         self._renderer.frame_size = video_resolution
-        self._renderer.pixel_aspect = 1.0
 
     def render(
         self, time: int, aspect_ratio: Union[float, Fraction] = Fraction(1, 1)


### PR DESCRIPTION
Storage size must be the actual encoded (i.e. stored) resolution of the
video stream, without any anamorphic de-squeeze applied. Other values
will lead to distorted rendering.

This will fix the the rendering for files with PlayRes different from
the video's storage resolution if the video is not anamorphic.
Anamorphic files are currently mistreated even beyond subtitle rendering
(at least with how ass_renderer is used by bubblesub) and will require
more effort to fix.
Nonetheless, this already constitutes a clear improvement.

Setting pixel aspect to 1.0 is also incorrect for anamorppic content.
If rendering at video resolution as ass_renderer does, libass can
calculate the pixel aspect itself if storage_size and frame_size
are both set correctly.

Reported in: https://github.com/bubblesub/bubblesub/issues/85